### PR TITLE
feat: support passing in ethereum provider directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3794,10 +3794,10 @@ console.log(fromToken);
 
 ### providerUrl
 
-This exposes the provider url it is using
+This exposes the provider url it is using will be undefined if you injected a ethereum provider
 
 ```ts
-get providerUrl(): string
+get providerUrl(): string | undefined
 ```
 
 #### Usage
@@ -3858,7 +3858,10 @@ const tokenContractAddress = '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b';
 
 const tokenFactoryPublic = new TokenFactoryPublic(
   toTokenContractAddress,
-  ChainId.MAINNET
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
 );
 
 const token = await tokenFactoryPublic.getToken();
@@ -3893,7 +3896,10 @@ const tokenContractAddress = '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b';
 
 const tokenFactoryPublic = new TokenFactoryPublic(
   toTokenContractAddress,
-  ChainId.MAINNET
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
 );
 
 const ethereumAddress = '0xB1E6079212888f0bE0cf55874B2EB9d7a5e02cD9';
@@ -3923,7 +3929,10 @@ const tokenContractAddress = '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b';
 
 const tokenFactoryPublic = new TokenFactoryPublic(
   toTokenContractAddress,
-  ChainId.MAINNET
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
 );
 
 const ethereumAddress = '0xB1E6079212888f0bE0cf55874B2EB9d7a5e02cD9';
@@ -3974,11 +3983,13 @@ import { TokenFactoryPublic, ChainId } from 'simple-uniswap-sdk';
 
 const tokenContractAddress = '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b';
 
-const tokenFactoryPublic = new TokenFactoryPublic(tokenContractAddress, {
-  chainId: ChainId.MAINNET,
-  // you can pass in the provider url as well if you want
-  // providerUrl: YOUR_PROVIDER_URL,
-});
+const tokenFactoryPublic = new TokenFactoryPublic(
+  tokenContractAddress,
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
+);
 
 // the contract address for which you are allowing to move tokens on your behalf
 const spender = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D';
@@ -4019,11 +4030,10 @@ const tokenContractAddress = '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b';
 
 const tokenFactoryPublic = new TokenFactoryPublic(
   tokenContractAddress,
-  {
-    chainId: ChainId.MAINNET,
-    // you can pass in the provider url as well if you want
-    // providerUrl: YOUR_PROVIDER_URL,
-  }
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
 );
 
 const ethereumAddress = '0xB1E6079212888f0bE0cf55874B2EB9d7a5e02cD9';
@@ -4066,11 +4076,12 @@ export interface Token {
 ```ts
 import { TokensFactoryPublic, ChainId } from 'simple-uniswap-sdk';
 
-const tokensFactoryPublic = new TokensFactoryPublic({
-  chainId: ChainId.MAINNET,
-  // you can pass in the provider url as well if you want
-  // providerUrl: YOUR_PROVIDER_URL,
-});
+const tokensFactoryPublic = new TokensFactoryPublic(
+  // this can take the same interface as pair context aka
+  // `ChainIdAndProvider` | `EthereumProvider`
+  // so you can pass in a providerUrl or a ethereumProvider
+  { chainId: ChainId.MAINNET }
+);
 
 const tokens = await tokensFactoryPublic.getTokens([
   '0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-uniswap-sdk",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Simple easy to understand SDK for uniswap which looks over best v2 and v3 to find you the best swap quote",
   "main": "dist/index.js",
   "scripts": {

--- a/src/__TEST-SCRIPT__/playground.ts
+++ b/src/__TEST-SCRIPT__/playground.ts
@@ -47,7 +47,7 @@ const routeTest = async () => {
   //   console.log(error.message);
   // }
 
-  // const ethers = new EthersProvider(ChainId.MAINNET);
+  // const ethers = new EthersProvider({ chainId: ChainId.MAINNET });
   // ethers.provider.estimateGas(trade.transaction);
 
   process.stdin.resume();

--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -10,9 +10,10 @@ export enum ErrorCodes {
   toTokenContractAddressNotValid = 9,
   ethereumAddressRequired = 10,
   ethereumAddressNotValid = 11,
-  youMustSupplyAChainId = 12,
+  invalidPairContext = 12,
   invalidFromOrToContractToken = 13,
   uniswapVersionNotSupported = 14,
   uniswapVersionsMustNotBeAnEmptyArray = 15,
   canNotFindProviderUrl = 16,
+  wrongEthersProviderContext = 17,
 }

--- a/src/ethers-provider.spec.ts
+++ b/src/ethers-provider.spec.ts
@@ -7,7 +7,7 @@ import { UniswapContractContextV2 } from './uniswap-contract-context/uniswap-con
 
 describe('EthersProvider', () => {
   describe('with chain id', () => {
-    const ethersProvider = new EthersProvider(ChainId.MAINNET);
+    const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
 
     it('getContract', () => {
       const result = ethersProvider.getContract<PairContractContext>(
@@ -38,14 +38,17 @@ describe('EthersProvider', () => {
   });
 
   describe('with chain id and providerUrl', () => {
-    const ethersProvider = new EthersProvider(
-      ChainId.MAINNET,
-      MOCK_PROVIDER_URL()
-    );
+    const ethersProvider = new EthersProvider({
+      chainId: ChainId.MAINNET,
+      providerUrl: MOCK_PROVIDER_URL(),
+    });
 
     it('should throw error if chainId not be found', () => {
       expect(() => {
-        new EthersProvider(10293, MOCK_PROVIDER_URL());
+        new EthersProvider({
+          chainId: 10293,
+          providerUrl: MOCK_PROVIDER_URL(),
+        });
       }).toThrowError(
         new UniswapError(
           'Can not find chain name for 10293',

--- a/src/factories/pair/models/uniswap-pair-contexts.ts
+++ b/src/factories/pair/models/uniswap-pair-contexts.ts
@@ -8,6 +8,11 @@ interface UniswapPairContextBase {
   settings?: UniswapPairSettings | undefined;
 }
 
+export interface UniswapPairContextForEthereumProvider
+  extends UniswapPairContextBase {
+  ethereumProvider: any;
+}
+
 export interface UniswapPairContextForChainId extends UniswapPairContextBase {
   chainId: ChainId | number;
 }

--- a/src/factories/pair/uniswap-pair.factory.spec.ts
+++ b/src/factories/pair/uniswap-pair.factory.spec.ts
@@ -16,10 +16,10 @@ import { TradeDirection } from './models/trade-direction';
 import { UniswapPairFactoryContext } from './models/uniswap-pair-factory-context';
 
 describe('UniswapPairFactory', () => {
-  const ethersProvider = new EthersProvider(
-    ChainId.MAINNET,
-    MOCK_PROVIDER_URL()
-  );
+  const ethersProvider = new EthersProvider({
+    chainId: ChainId.MAINNET,
+    providerUrl: MOCK_PROVIDER_URL(),
+  });
   describe('erc20 > erc20', () => {
     const uniswapPairFactoryContext: UniswapPairFactoryContext = {
       fromToken: MOCKFUN(),

--- a/src/factories/pair/uniswap-pair.factory.ts
+++ b/src/factories/pair/uniswap-pair.factory.ts
@@ -79,7 +79,7 @@ export class UniswapPairFactory {
   /**
    * Get the provider url
    */
-  public get providerUrl(): string {
+  public get providerUrl(): string | undefined {
     return this._uniswapPairFactoryContext.ethersProvider.getProviderUrl();
   }
 

--- a/src/factories/pair/uniswap-pair.spec.ts
+++ b/src/factories/pair/uniswap-pair.spec.ts
@@ -1,3 +1,4 @@
+import { providers } from 'ethers';
 import { ChainId, ErrorCodes, UniswapError } from '../..';
 import { MockEthereumAddress } from '../../mocks/ethereum-address.mock';
 import { MOCKFUN } from '../../mocks/fun-token.mock';
@@ -5,6 +6,7 @@ import { MOCK_PROVIDER_URL } from '../../mocks/provider-url.mock';
 import { MOCKREP } from '../../mocks/rep-token.mock';
 import {
   UniswapPairContextForChainId,
+  UniswapPairContextForEthereumProvider,
   UniswapPairContextForProviderUrl,
 } from './models/uniswap-pair-contexts';
 import { UniswapPair } from './uniswap-pair';
@@ -90,7 +92,7 @@ describe('UniswapPair', () => {
     );
   });
 
-  it('should throw if no chainId is passed in', () => {
+  it('should throw if no chainId or ethereum provider passed in', () => {
     // @ts-ignore
     const context: UniswapPairContextForChainId = {
       fromTokenContractAddress: MOCKFUN().contractAddress,
@@ -99,8 +101,8 @@ describe('UniswapPair', () => {
     };
     expect(() => new UniswapPair(context)).toThrowError(
       new UniswapError(
-        'You must have a chainId on the context.',
-        ErrorCodes.youMustSupplyAChainId
+        'Your must supply a chainId or a ethereum provider please look at types `UniswapPairContextForEthereumProvider`, `UniswapPairContextForChainId` and `UniswapPairContextForProviderUrl` to make sure your object is correct in what your passing in',
+        ErrorCodes.invalidPairContext
       )
     );
   });
@@ -126,6 +128,20 @@ describe('UniswapPair', () => {
       ethereumAddress: MockEthereumAddress(),
       chainId: ChainId.MAINNET,
       providerUrl: MOCK_PROVIDER_URL(),
+    };
+
+    const uniswapPair = new UniswapPair(context);
+
+    //@ts-ignore
+    expect(typeof uniswapPair._ethersProvider).not.toBeUndefined();
+  });
+
+  it('should create ethers provider', () => {
+    const context: UniswapPairContextForEthereumProvider = {
+      fromTokenContractAddress: MOCKFUN().contractAddress,
+      toTokenContractAddress: MOCKREP().contractAddress,
+      ethereumAddress: MockEthereumAddress(),
+      ethereumProvider: new providers.JsonRpcProvider(MOCK_PROVIDER_URL()),
     };
 
     const uniswapPair = new UniswapPair(context);

--- a/src/factories/pair/uniswap-pair.ts
+++ b/src/factories/pair/uniswap-pair.ts
@@ -6,6 +6,7 @@ import { EthersProvider } from '../../ethers-provider';
 import { TokensFactory } from '../token/tokens.factory';
 import {
   UniswapPairContextForChainId,
+  UniswapPairContextForEthereumProvider,
   UniswapPairContextForProviderUrl,
 } from './models/uniswap-pair-contexts';
 import { UniswapPairFactoryContext } from './models/uniswap-pair-factory-context';
@@ -19,6 +20,7 @@ export class UniswapPair {
     private _uniswapPairContext:
       | UniswapPairContextForChainId
       | UniswapPairContextForProviderUrl
+      | UniswapPairContextForEthereumProvider
   ) {
     if (!this._uniswapPairContext.fromTokenContractAddress) {
       throw new UniswapError(
@@ -82,18 +84,27 @@ export class UniswapPair {
     )).providerUrl;
 
     if (providerUrl && chainId) {
-      this._ethersProvider = new EthersProvider(chainId, providerUrl);
+      this._ethersProvider = new EthersProvider({ chainId, providerUrl });
       return;
     }
 
     if (chainId) {
-      this._ethersProvider = new EthersProvider(chainId);
+      this._ethersProvider = new EthersProvider({ chainId });
+      return;
+    }
+
+    const ethereumProvider = (<UniswapPairContextForEthereumProvider>(
+      this._uniswapPairContext
+    )).ethereumProvider;
+
+    if (ethereumProvider) {
+      this._ethersProvider = new EthersProvider({ ethereumProvider });
       return;
     }
 
     throw new UniswapError(
-      'You must have a chainId on the context.',
-      ErrorCodes.youMustSupplyAChainId
+      'Your must supply a chainId or a ethereum provider please look at types `UniswapPairContextForEthereumProvider`, `UniswapPairContextForChainId` and `UniswapPairContextForProviderUrl` to make sure your object is correct in what your passing in',
+      ErrorCodes.invalidPairContext
     );
   }
 

--- a/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.spec.ts
+++ b/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.spec.ts
@@ -4,9 +4,8 @@ import { MOCKFUN } from '../../../mocks/fun-token.mock';
 import { UniswapPairContractFactoryPublicV2 } from './uniswap-pair-contract.factory.public.v2';
 
 describe('UniswapPairContractFactoryPublicV2', () => {
-  const uniswapPairContractFactoryPublic = new UniswapPairContractFactoryPublicV2(
-    ChainId.MAINNET
-  );
+  const uniswapPairContractFactoryPublic =
+    new UniswapPairContractFactoryPublicV2({ chainId: ChainId.MAINNET });
 
   it('allPairs', async () => {
     const result = await uniswapPairContractFactoryPublic.allPairs('0x01');

--- a/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.ts
+++ b/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.ts
@@ -4,6 +4,6 @@ import { UniswapPairContractFactoryV2 } from './uniswap-pair-contract.factory.v2
 
 export class UniswapPairContractFactoryPublicV2 extends UniswapPairContractFactoryV2 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.ts
+++ b/src/factories/pair/v2/uniswap-pair-contract.factory.public.v2.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapPairContractFactoryV2 } from './uniswap-pair-contract.factory.v2';
 
 export class UniswapPairContractFactoryPublicV2 extends UniswapPairContractFactoryV2 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/pair/v2/uniswap-pair-contract.factory.v2.spec.ts
+++ b/src/factories/pair/v2/uniswap-pair-contract.factory.v2.spec.ts
@@ -5,7 +5,7 @@ import { MOCKFUN } from '../../../mocks/fun-token.mock';
 import { UniswapPairContractFactoryV2 } from './uniswap-pair-contract.factory.v2';
 
 describe('UniswapPairContractFactoryV2', () => {
-  const ethersProvider = new EthersProvider(ChainId.MAINNET);
+  const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
 
   const uniswapPairContractFactory = new UniswapPairContractFactoryV2(
     ethersProvider

--- a/src/factories/router/uniswap-router.factory.spec.ts
+++ b/src/factories/router/uniswap-router.factory.spec.ts
@@ -10,7 +10,7 @@ import { TradeDirection } from '../pair/models/trade-direction';
 import { UniswapRouterFactory } from './uniswap-router.factory';
 
 describe('UniswapRouterFactory', () => {
-  const ethersProvider = new EthersProvider(ChainId.MAINNET);
+  const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
 
   describe('erc20 > erc20', () => {
     const fromToken = MOCKAAVE();
@@ -255,7 +255,7 @@ describe('UniswapRouterFactory', () => {
           );
           if (result.bestRouteQuote.uniswapVersion === UniswapVersion.v2) {
             expect(result.bestRouteQuote.routeText).toEqual(
-              'AAVE > WETH > USDT > UNI'
+              'AAVE > WETH > UNI'
             );
           } else {
             expect(result.bestRouteQuote.routeText).toEqual('AAVE > UNI');

--- a/src/factories/router/v2/uniswap-router-contract.factory.public.v2.ts
+++ b/src/factories/router/v2/uniswap-router-contract.factory.public.v2.ts
@@ -4,6 +4,6 @@ import { UniswapRouterContractFactoryV2 } from './uniswap-router-contract.factor
 
 export class UniswapRouterContractFactoryV2Public extends UniswapRouterContractFactoryV2 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/router/v2/uniswap-router-contract.factory.public.v2.ts
+++ b/src/factories/router/v2/uniswap-router-contract.factory.public.v2.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapRouterContractFactoryV2 } from './uniswap-router-contract.factory.v2';
 
 export class UniswapRouterContractFactoryV2Public extends UniswapRouterContractFactoryV2 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/router/v3/uniswap-router-contract.factory.public.v3.ts
+++ b/src/factories/router/v3/uniswap-router-contract.factory.public.v3.ts
@@ -4,6 +4,6 @@ import { UniswapRouterContractFactoryV3 } from './uniswap-router-contract.factor
 
 export class UniswapRouterContractFactoryV3Public extends UniswapRouterContractFactoryV3 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/router/v3/uniswap-router-contract.factory.public.v3.ts
+++ b/src/factories/router/v3/uniswap-router-contract.factory.public.v3.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapRouterContractFactoryV3 } from './uniswap-router-contract.factory.v3';
 
 export class UniswapRouterContractFactoryV3Public extends UniswapRouterContractFactoryV3 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/token/token.factory.public.spec.ts
+++ b/src/factories/token/token.factory.public.spec.ts
@@ -8,10 +8,9 @@ import { UniswapContractContextV3 } from '../../uniswap-contract-context/uniswap
 describe('TokenFactoryPublic', () => {
   const token = MOCKFUN();
 
-  const tokenFactoryPublic = new TokenFactoryPublic(
-    token.contractAddress,
-    ChainId.MAINNET
-  );
+  const tokenFactoryPublic = new TokenFactoryPublic(token.contractAddress, {
+    chainId: ChainId.MAINNET,
+  });
 
   it('getToken', async () => {
     const result = await tokenFactoryPublic.getToken();

--- a/src/factories/token/token.factory.public.ts
+++ b/src/factories/token/token.factory.public.ts
@@ -1,13 +1,15 @@
-import { ChainId } from '../../enums/chain-id';
-import { EthersProvider } from '../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../ethers-provider';
 import { TokenFactory } from './token.factory';
 
 export class TokenFactoryPublic extends TokenFactory {
   constructor(
     tokenContractAddress: string,
-    chainId: ChainId,
-    providerUrl?: string | undefined
+    providerContext: ChainIdAndProvider | EthereumProvider
   ) {
-    super(tokenContractAddress, new EthersProvider({ chainId, providerUrl }));
+    super(tokenContractAddress, new EthersProvider(providerContext));
   }
 }

--- a/src/factories/token/token.factory.public.ts
+++ b/src/factories/token/token.factory.public.ts
@@ -8,6 +8,6 @@ export class TokenFactoryPublic extends TokenFactory {
     chainId: ChainId,
     providerUrl?: string | undefined
   ) {
-    super(tokenContractAddress, new EthersProvider(chainId, providerUrl));
+    super(tokenContractAddress, new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/token/token.factory.spec.ts
+++ b/src/factories/token/token.factory.spec.ts
@@ -8,7 +8,7 @@ import { UniswapContractContextV3 } from '../../uniswap-contract-context/uniswap
 import { TokenFactory } from './token.factory';
 
 describe('TokenFactory', () => {
-  const ethersProvider = new EthersProvider(ChainId.MAINNET);
+  const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
   const token = MOCKFUN();
 
   const tokenFactory = new TokenFactory(token.contractAddress, ethersProvider);

--- a/src/factories/token/tokens.factory.public.spec.ts
+++ b/src/factories/token/tokens.factory.public.spec.ts
@@ -3,7 +3,9 @@ import { MOCKFUN } from '../../mocks/fun-token.mock';
 import { MOCKREP } from '../../mocks/rep-token.mock';
 
 describe('TokensFactoryPublic', () => {
-  const tokensFactoryPublic = new TokensFactoryPublic(ChainId.MAINNET);
+  const tokensFactoryPublic = new TokensFactoryPublic({
+    chainId: ChainId.MAINNET,
+  });
 
   describe('getTokens', () => {
     it('should return both token info', async () => {

--- a/src/factories/token/tokens.factory.public.ts
+++ b/src/factories/token/tokens.factory.public.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../enums/chain-id';
-import { EthersProvider } from '../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../ethers-provider';
 import { TokensFactory } from './tokens.factory';
 
 export class TokensFactoryPublic extends TokensFactory {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/token/tokens.factory.public.ts
+++ b/src/factories/token/tokens.factory.public.ts
@@ -4,6 +4,6 @@ import { TokensFactory } from './tokens.factory';
 
 export class TokensFactoryPublic extends TokensFactory {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/token/tokens.factory.spec.ts
+++ b/src/factories/token/tokens.factory.spec.ts
@@ -5,7 +5,7 @@ import { MOCKREP } from '../../mocks/rep-token.mock';
 import { TokensFactory } from './tokens.factory';
 
 describe('TokensFactory', () => {
-  const ethersProvider = new EthersProvider(ChainId.MAINNET);
+  const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
 
   const tokensFactory = new TokensFactory(ethersProvider);
 

--- a/src/factories/uniswap-factory/v2/uniswap-contract.factory.public.v2.spec.ts
+++ b/src/factories/uniswap-factory/v2/uniswap-contract.factory.public.v2.spec.ts
@@ -4,9 +4,9 @@ import { MOCKFUN } from '../../../mocks/fun-token.mock';
 import { UniswapContractFactoryV2Public } from './uniswap-contract.factory.v2.public';
 
 describe('UniswapContractFactoryV2Public', () => {
-  const uniswapContractFactoryPublic = new UniswapContractFactoryV2Public(
-    ChainId.MAINNET
-  );
+  const uniswapContractFactoryPublic = new UniswapContractFactoryV2Public({
+    chainId: ChainId.MAINNET,
+  });
 
   it('allPairs', async () => {
     const result = await uniswapContractFactoryPublic.allPairs('0x01');

--- a/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.public.ts
+++ b/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.public.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapContractFactoryV2 } from './uniswap-contract.factory.v2';
 
 export class UniswapContractFactoryV2Public extends UniswapContractFactoryV2 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.public.ts
+++ b/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.public.ts
@@ -4,6 +4,6 @@ import { UniswapContractFactoryV2 } from './uniswap-contract.factory.v2';
 
 export class UniswapContractFactoryV2Public extends UniswapContractFactoryV2 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.spec.ts
+++ b/src/factories/uniswap-factory/v2/uniswap-contract.factory.v2.spec.ts
@@ -5,7 +5,7 @@ import { MOCKFUN } from '../../../mocks/fun-token.mock';
 import { UniswapContractFactoryV2 } from './uniswap-contract.factory.v2';
 
 describe('UniswapContractFactoryV2', () => {
-  const ethersProvider = new EthersProvider(ChainId.MAINNET);
+  const ethersProvider = new EthersProvider({ chainId: ChainId.MAINNET });
 
   const uniswapContractFactory = new UniswapContractFactoryV2(ethersProvider);
 

--- a/src/factories/uniswap-factory/v3/uniswap-contract.factory.v3.public.ts
+++ b/src/factories/uniswap-factory/v3/uniswap-contract.factory.v3.public.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapContractFactoryV3 } from './uniswap-contract.factory.v3';
 
 export class UniswapContractFactoryV3Public extends UniswapContractFactoryV3 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }

--- a/src/factories/uniswap-factory/v3/uniswap-contract.factory.v3.public.ts
+++ b/src/factories/uniswap-factory/v3/uniswap-contract.factory.v3.public.ts
@@ -4,6 +4,6 @@ import { UniswapContractFactoryV3 } from './uniswap-contract.factory.v3';
 
 export class UniswapContractFactoryV3Public extends UniswapContractFactoryV3 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/uniswap-quoter/v3/uniswap-contract.quoter.v3.public.ts
+++ b/src/factories/uniswap-quoter/v3/uniswap-contract.quoter.v3.public.ts
@@ -4,6 +4,6 @@ import { UniswapContractQuoterV3 } from './uniswap-contract.quoter.v3';
 
 export class UniswapContractQuoterV3Public extends UniswapContractQuoterV3 {
   constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider(chainId, providerUrl));
+    super(new EthersProvider({ chainId, providerUrl }));
   }
 }

--- a/src/factories/uniswap-quoter/v3/uniswap-contract.quoter.v3.public.ts
+++ b/src/factories/uniswap-quoter/v3/uniswap-contract.quoter.v3.public.ts
@@ -1,9 +1,12 @@
-import { ChainId } from '../../../enums/chain-id';
-import { EthersProvider } from '../../../ethers-provider';
+import {
+  ChainIdAndProvider,
+  EthereumProvider,
+  EthersProvider,
+} from '../../../ethers-provider';
 import { UniswapContractQuoterV3 } from './uniswap-contract.quoter.v3';
 
 export class UniswapContractQuoterV3Public extends UniswapContractQuoterV3 {
-  constructor(chainId: ChainId, providerUrl?: string | undefined) {
-    super(new EthersProvider({ chainId, providerUrl }));
+  constructor(providerContext: ChainIdAndProvider | EthereumProvider) {
+    super(new EthersProvider(providerContext));
   }
 }


### PR DESCRIPTION
Create feature asked for the ability to pass in your ethereum provider directly - https://github.com/uniswap-integration/simple-uniswap-sdk/issues/7

- breaking change on the public factories as you now have to pass it `ChainIdAndProvider` | `EthereumProvider`